### PR TITLE
Title and intro copy

### DIFF
--- a/pages/content/getting-started.md
+++ b/pages/content/getting-started.md
@@ -4,7 +4,7 @@ title: Getting started
 permalink: /content-design/getting-started/
 ---
 
-## Accessibility for content design
+## Accessibility for content designers
 
 Accessible writing ensures your content is easier for everyone to read. As we build government services, we want to ensure they are accessible and welcoming to everyone who needs to use them.
 

--- a/pages/front-end/getting-started.md
+++ b/pages/front-end/getting-started.md
@@ -4,7 +4,7 @@ title: Getting started
 permalink: /front-end/getting-started/
 ---
 
-## Accessibility for front end developers
+## Accessibility for front-end developers
 
 Accessible front end development ensures people with different abilities can access, understand, and navigate web content, regardless of how they're accessing it. Front-end developers collaborate with other members of a cross-fuctional team to implement a robust user experience.
 

--- a/pages/front-end/getting-started.md
+++ b/pages/front-end/getting-started.md
@@ -6,7 +6,7 @@ permalink: /front-end/getting-started/
 
 ## Accessibility for front-end developers
 
-Accessible front end development ensures people with different abilities can access, understand, and navigate web content, regardless of how they're accessing it. Front-end developers collaborate with other members of a cross-fuctional team to implement a robust user experience.
+Accessible front-end development ensures people with different abilities can access, understand, and navigate web content, regardless of how they're accessing it. Front-end developers collaborate with other members of a cross-fuctional team to implement a robust user experience.
 
 ### How to use this guide
 

--- a/pages/front-end/getting-started.md
+++ b/pages/front-end/getting-started.md
@@ -4,9 +4,9 @@ title: Getting started
 permalink: /front-end/getting-started/
 ---
 
-## Accessibility for front-end development
+## Accessibility for front end developers
 
-Accessible front-end development ensures people with different abilities can access, understand, and navigate web content, regardless of how they're accessing it. Front-end developers collaborate with other members of a cross-fuctional team to implement a robust user experience.
+Accessible front end development ensures people with different abilities can access, understand, and navigate web content, regardless of how they're accessing it. Front-end developers collaborate with other members of a cross-fuctional team to implement a robust user experience.
 
 ### How to use this guide
 

--- a/pages/home.md
+++ b/pages/home.md
@@ -24,7 +24,7 @@ permalink: /
   <li>
     <a href="{{ site.baseurl }}/ux/getting-started/">
       <img src="{{ site.baseurl }}/assets/img/icons/ux.svg" alt="">
-      <p>UX<i class="fa fa-chevron-right" aria-hidden="true"></i></p>
+      <p>Interaction design<i class="fa fa-chevron-right" aria-hidden="true"></i></p>
     </a>
   </li>
   <li>

--- a/pages/home.md
+++ b/pages/home.md
@@ -7,7 +7,8 @@ title: Home
 permalink: /
 ---
 
-<h2>Choose a guide</h2>
+<p>Everyone who works on government websites has a role to play in making federal resources accessible and inclusive.</p>
+<p>Choose the guide that fits your role:</p>
 <ul class="home-roles-list">
   <li>
     <a href="{{ site.baseurl }}/product/getting-started/">
@@ -24,7 +25,7 @@ permalink: /
   <li>
     <a href="{{ site.baseurl }}/ux/getting-started/">
       <img src="{{ site.baseurl }}/assets/img/icons/ux.svg" alt="">
-      <p>Interaction design<i class="fa fa-chevron-right" aria-hidden="true"></i></p>
+      <p>UX<i class="fa fa-chevron-right" aria-hidden="true"></i></p>
     </a>
   </li>
   <li>
@@ -41,13 +42,13 @@ permalink: /
   </li>
 </ul>
 
-<h2>How to use this guide</h2>
+<h2>About this guide</h2>
 This is a 'quick-start' guide for embedding accessibility and inclusive design practices into your team's workflow. It provides:
 
 - An overview of how each team member can contribute to a product's accessibility
 - A framework for thinking about accessibility and inclusive design in your role
-- An understanding of the human need behind accessibility practices.
+- An understanding of the human need behind accessibility practices
 
-We choose to focus on issues most likely to impact government sites. These guidelines do not provide a comprehensive list of all possible issues. Your team will need additional resources and work to conducting manual audits and prepare for the January 2018 deadline to be compliant with [WCAG 2.0 standards](https://www.w3.org/TR/WCAG20/).
+We focus on the issues most likely to impact government sites. These guidelines do not provide a comprehensive list of all possible issues. Your team will need additional resources and work to conduct manual audits and prepare for the January 2018 deadline to be compliant with [WCAG 2.0 standards](https://www.w3.org/TR/WCAG20/).
 
 Questions or comments? Please reach out to us in the project's [GitHub issues](https://github.com/18F/accessibility-playbook/issues/) or email [g-accessibility@gsa.gov](mailto:g-accessibility@gsa.gov).

--- a/pages/product/getting-started.md
+++ b/pages/product/getting-started.md
@@ -4,7 +4,7 @@ title: Getting started
 permalink: /product/getting-started/
 ---
 
-## Accessibility for product management
+## Accessibility for product managers
 
 Product managers play a vital role in communicating accessibility requirements early in the project lifecycle, ensuring each team member knows their responsibility, and keeping the team accountable for building accessible products. Following these steps, you’ll make sure you’re not only following legal requirements, but making your product more usable for everyone.
 

--- a/pages/ux/getting-started.md
+++ b/pages/ux/getting-started.md
@@ -4,7 +4,7 @@ title: Getting started
 permalink: /ux/getting-started/
 ---
 
-## Accessibility for user experience (UX) design
+## Accessibility for user experience (UX) designers
 
 Accessibility is usability for people who interact with products differently. Your role is to help the team approach accessibility as a facet of user experience rather than checklist of requirements.
 

--- a/pages/visual-design/getting-started.md
+++ b/pages/visual-design/getting-started.md
@@ -4,7 +4,7 @@ title: Getting started
 permalink: /visual-design/getting-started/
 ---
 
-## Accessibility for visual design
+## Accessibility for visual designers
 
 Everyone benefits from designs that are easier to see. People with different visual abilities see your designs in varying ways—the diverse nature of impairments creates a wide variation in how your designs are perceived. A clean and clear visual presentation helps everyone make sense of a website's information and functionality.
 


### PR DESCRIPTION
Addresses #10.

- The existing button labels on the homepage are tricky to tweak without introducing awkward design/layout issues...
- BUT I think we can solve the underlying confusion about what the short titles mean by adding brief introductory text above the buttons on the homepage...
- AND it will help clarify the "role-based" aspect of the page to lengthen page titles slightly so they refer to humans/roles instead of disciplines

The changes in this PR include:

- Added brief homepage copy above the buttons
- Adjusted header language on the homepage for clarity
- Minor copyediting in the intro text on the homepage
- Lengthened the titles of each guide to refer to humans (or roles humans play)